### PR TITLE
feature(Dockerfile): add xmlsec package to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM python:3.9.1-alpine3.13
 RUN /usr/local/bin/python -m pip install --upgrade pip
-RUN apk  --no-cache add git gcc cmake make g++ libffi-dev openssl-dev git cairo pango mysql mysql-client  gettext mariadb-connector-c-dev gcc g++  libffi-dev libc-dev 
+RUN apk  --no-cache add git gcc cmake make g++ libffi-dev openssl-dev git cairo pango mysql mysql-client  gettext mariadb-connector-c-dev gcc g++  libffi-dev libc-dev xmlsec xmlsec-dev
 


### PR DESCRIPTION
For one of our projects, we need [`xmlsec`](https://pypi.org/project/xmlsec/) package, which requires `xmlsec` and `xmlsec-dev` alpine packages that I add in this PR.